### PR TITLE
Improve monitor mode selection and scaling precision

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -172,7 +172,20 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
   Future<void> _updateConnectedMonitors() async {
     try {
       List<MonitorTileData> monitors = await getConnectedMonitors();
-      setState(() => currentMonitors = monitors);
+      setState(() {
+        currentMonitors = monitors;
+        for (final profile in profiles) {
+          for (var i = 0; i < profile.monitors.length; i++) {
+            final connected = monitors.firstWhere(
+              (m) => m.manufacturer.trim() ==
+                  profile.monitors[i].manufacturer.trim(),
+              orElse: () => profile.monitors[i],
+            );
+            profile.monitors[i] =
+                profile.monitors[i].copyWith(modes: connected.modes);
+          }
+        }
+      });
     } catch (e) {
       debugPrint('Error getting connected monitors: $e');
     }
@@ -304,6 +317,13 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
   void _onMonitorScale(String id, double newScale, BoxConstraints constraints) {
     if (activeProfileIndex == null) return;
     final mons = activeMonitors;
+    for (int n = 1; n <= 8; n++) {
+      if ((newScale - n).abs() < 0.05) {
+        newScale = n.toDouble();
+        break;
+      }
+    }
+    newScale = double.parse(newScale.toStringAsFixed(2));
     final index = mons.indexWhere((m) => m.id == id);
     if (index == -1) return;
     final updated = mons[index].copyWith(scale: newScale);

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -121,7 +121,7 @@ class ConfigService {
         final transform = m.rotation == 0 ? 'normal' : m.rotation.toString();
 
         buffer.writeln(
-          "    output '${m.id}' enable scale ${m.scale} "
+          "    output '${m.id}' enable scale ${m.scale.toStringAsFixed(2)} "
           "mode ${baseW.toInt()}x${baseH.toInt()} "
           "transform $transform position $posX,$posY",
         );

--- a/lib/widgets/monitor_tile.dart
+++ b/lib/widgets/monitor_tile.dart
@@ -171,15 +171,23 @@ class _MonitorTileState extends State<MonitorTile> {
               cursor: SystemMouseCursors.resizeUpLeftDownRight,
               child: GestureDetector(
                 onPanUpdate: (details) {
-                  setState(() {
-                    tileWidth += details.delta.dx;
-                    tileHeight += details.delta.dy;
-                    if (tileWidth < 20) tileWidth = 20;
-                    if (tileHeight < 20) tileHeight = 20;
-                  });
-                  final newScale = widget.originalWidth /
-                      ((tileWidth) / widget.scaleFactor);
-                  widget.onScale?.call(newScale);
+                    setState(() {
+                      tileWidth += details.delta.dx;
+                      tileHeight += details.delta.dy;
+                      if (tileWidth < 20) tileWidth = 20;
+                      if (tileHeight < 20) tileHeight = 20;
+                    });
+                    var newScale = widget.originalWidth / ((tileWidth) / widget.scaleFactor);
+                    for (int n = 1; n <= 8; n++) {
+                      if ((newScale - n).abs() < 0.05) {
+                        newScale = n.toDouble();
+                        tileWidth = widget.originalWidth / newScale * widget.scaleFactor;
+                        tileHeight = widget.originalHeight / newScale * widget.scaleFactor;
+                        break;
+                      }
+                    }
+                    newScale = double.parse(newScale.toStringAsFixed(2));
+                    widget.onScale?.call(newScale);
                 },
                 child: Container(
                   width: 16,


### PR DESCRIPTION
## Summary
- round scale factors to two decimals and snap near integers
- propagate available modes for connected monitors
- write scales with two decimals in config

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b8b0154083228177434cb6014e57