### PR TITLE
Reset keyboard state at startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 // lib/main.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'pages/home_page.dart';
 
 /*
@@ -20,6 +21,10 @@ import 'pages/home_page.dart';
  * along with kanshi_gui. If not, see <https://www.gnu.org/licenses/>.
  */
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  // Reset any leftover keyboard state that might cause assertion errors
+  // when a key down event is received while considered already pressed.
+  HardwareKeyboard.instance.clearState();
   runApp(const KanshiApp());
 }
 


### PR DESCRIPTION
## Summary
- reset pressed key state on startup using `HardwareKeyboard`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bba5c81c832280c59e33ab7e447a