### PR TITLE
Add Debian packaging helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Currently, _kanshi_gui does not claim to map all functionalities of kanshi_ in a
    kanshi_gui
    ```
 
+2. **Create a Debian package**:
+   The repository ships with a helper script that bundles the application
+   into a `.deb` file. Run it from the project root and then install the
+   resulting package with `dpkg`:
+   ```bash
+   ./scripts/build_deb.sh
+   sudo dpkg -i build/kanshi_gui_*.deb
+   ```
+   After installation the `kanshi_gui` command is available globally. To
+   remove the package again use:
+   ```bash
+   sudo dpkg -r kanshi_gui
+   ```
+
 # License
 
 Copyright (C) 2025 nurkert - This project is licensed under the terms of the [GNU General Public License v3.0](LICENSE).

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+APP_NAME="kanshi_gui"
+ARCH="amd64"
+VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d'+' -f1)
+
+# Build Flutter bundle
+flutter build linux
+
+PKG_DIR="build/debian/${APP_NAME}_${VERSION}"
+rm -rf "$PKG_DIR"
+mkdir -p "$PKG_DIR/DEBIAN"
+mkdir -p "$PKG_DIR/usr/lib/$APP_NAME"
+mkdir -p "$PKG_DIR/usr/bin"
+mkdir -p "$PKG_DIR/usr/share/applications"
+mkdir -p "$PKG_DIR/usr/share/pixmaps"
+
+# Copy build output
+cp -r build/linux/x64/release/bundle/* "$PKG_DIR/usr/lib/$APP_NAME/"
+
+# Launcher script
+cat > "$PKG_DIR/usr/bin/$APP_NAME" <<'EOS'
+#!/bin/sh
+exec /usr/lib/kanshi_gui/kanshi_gui "$@"
+EOS
+chmod 755 "$PKG_DIR/usr/bin/$APP_NAME"
+
+# Desktop file and icon
+cp debian/gui/kanshi_gui.desktop "$PKG_DIR/usr/share/applications/"
+cp assets/kanshi_gui.png "$PKG_DIR/usr/share/pixmaps/"
+
+# Control file
+cat > "$PKG_DIR/DEBIAN/control" <<EOS
+Package: $APP_NAME
+Version: $VERSION
+Architecture: $ARCH
+Maintainer: nurkert
+Priority: optional
+Description: A simple GUI for kanshi.
+EOS
+
+DEB_FILE="build/${APP_NAME}_${VERSION}_${ARCH}.deb"
+dpkg-deb --build "$PKG_DIR" "$DEB_FILE"
+
+echo "Package built: $DEB_FILE"


### PR DESCRIPTION
## Summary
- add `scripts/build_deb.sh` to build a `.deb` installer
- document how to use the script in the README

## Testing
- `./scripts/build_deb.sh` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684762bb43d4832298f330081aa03c4b