### PR TITLE
Fix crash when saving empty profiles

### DIFF
--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -95,6 +95,7 @@ class ConfigService {
     final buffer = StringBuffer();
 
     for (final profile in profiles) {
+      if (profile.monitors.isEmpty) continue;
       // Negative Koordinaten zu Null klappen
       final minX =
           profile.monitors.map((m) => m.x).reduce((a, b) => a < b ? a : b);


### PR DESCRIPTION
## Summary
- avoid calling `reduce` on an empty monitor list in `saveProfiles`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc3458a3c832281a603b7fa7f890c