### PR TITLE
Add Debian dependencies and sanitize package name

### DIFF
--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -4,11 +4,12 @@ set -e
 APP_NAME="kanshi_gui"
 ARCH="amd64"
 VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d'+' -f1)
+DEB_PACKAGE_NAME="${APP_NAME//_/-}"
 
 # Build Flutter bundle
 flutter build linux
 
-PKG_DIR="build/debian/${APP_NAME}_${VERSION}"
+PKG_DIR="build/debian/${DEB_PACKAGE_NAME}_${VERSION}"
 rm -rf "$PKG_DIR"
 mkdir -p "$PKG_DIR/DEBIAN"
 mkdir -p "$PKG_DIR/usr/lib/$APP_NAME"
@@ -32,15 +33,16 @@ cp assets/kanshi_gui.png "$PKG_DIR/usr/share/pixmaps/"
 
 # Control file
 cat > "$PKG_DIR/DEBIAN/control" <<EOS
-Package: $APP_NAME
+Package: $DEB_PACKAGE_NAME
 Version: $VERSION
 Architecture: $ARCH
 Maintainer: nurkert
+Depends: libc6, libstdc++6, libgcc-s1, libgtk-3-0, libglib2.0-0, libgdk-pixbuf-2.0-0, libpango-1.0-0, libpangocairo-1.0-0, libatk1.0-0, libatk-bridge2.0-0, libharfbuzz0b, libcairo2, libepoxy0, libdbus-1-3, zlib1g
 Priority: optional
 Description: A simple GUI for kanshi.
 EOS
 
-DEB_FILE="build/${APP_NAME}_${VERSION}_${ARCH}.deb"
+DEB_FILE="build/${DEB_PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
 dpkg-deb --build "$PKG_DIR" "$DEB_FILE"
 
 echo "Package built: $DEB_FILE"


### PR DESCRIPTION
## Summary
- update the Debian build script to derive a hyphenated package name
- record the runtime library dependencies discovered from the ldd output in the control file

## Testing
- `scripts/build_deb.sh`
- `sudo chroot /tmp/debian-root /bin/bash -c "apt-get install -y --fix-broken"`
- `sudo chroot /tmp/debian-root /bin/bash -c "dpkg -l kanshi-gui"`


------
https://chatgpt.com/codex/tasks/task_e_68dce7d286e8832296b5bc551af42d97