### PR TITLE
Detect host architecture in Debian packaging script

### DIFF
--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -2,12 +2,35 @@
 set -e
 
 APP_NAME="kanshi_gui"
-ARCH="amd64"
+# Determine architectures
+DEB_ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+
+case "$DEB_ARCH" in
+  amd64|x86_64)
+    FLUTTER_ARCH="x64"
+    TARGET_PLATFORM="linux-x64"
+    DEB_ARCH="amd64"
+    ;;
+  arm64|aarch64)
+    FLUTTER_ARCH="arm64"
+    TARGET_PLATFORM="linux-arm64"
+    DEB_ARCH="arm64"
+    ;;
+  armhf|armv7l)
+    FLUTTER_ARCH="arm"
+    TARGET_PLATFORM="linux-arm32"
+    DEB_ARCH="armhf"
+    ;;
+  *)
+    echo "Unsupported architecture: $DEB_ARCH" >&2
+    exit 1
+    ;;
+esac
 VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d'+' -f1)
 DEB_PACKAGE_NAME="${APP_NAME//_/-}"
 
 # Build Flutter bundle
-flutter build linux
+flutter build linux --target-platform="$TARGET_PLATFORM"
 
 PKG_DIR="build/debian/${DEB_PACKAGE_NAME}_${VERSION}"
 rm -rf "$PKG_DIR"
@@ -18,7 +41,12 @@ mkdir -p "$PKG_DIR/usr/share/applications"
 mkdir -p "$PKG_DIR/usr/share/pixmaps"
 
 # Copy build output
-cp -r build/linux/x64/release/bundle/* "$PKG_DIR/usr/lib/$APP_NAME/"
+BUILD_BUNDLE_DIR="build/linux/$FLUTTER_ARCH/release/bundle"
+if [ ! -d "$BUILD_BUNDLE_DIR" ]; then
+  echo "Flutter build output not found for architecture $FLUTTER_ARCH at $BUILD_BUNDLE_DIR" >&2
+  exit 1
+fi
+cp -r "$BUILD_BUNDLE_DIR"/* "$PKG_DIR/usr/lib/$APP_NAME/"
 
 # Launcher script
 cat > "$PKG_DIR/usr/bin/$APP_NAME" <<'EOS'
@@ -35,14 +63,14 @@ cp assets/kanshi_gui.png "$PKG_DIR/usr/share/pixmaps/"
 cat > "$PKG_DIR/DEBIAN/control" <<EOS
 Package: $DEB_PACKAGE_NAME
 Version: $VERSION
-Architecture: $ARCH
+Architecture: $DEB_ARCH
 Maintainer: nurkert
 Depends: libc6, libstdc++6, libgcc-s1, libgtk-3-0, libglib2.0-0, libgdk-pixbuf-2.0-0, libpango-1.0-0, libpangocairo-1.0-0, libatk1.0-0, libatk-bridge2.0-0, libharfbuzz0b, libcairo2, libepoxy0, libdbus-1-3, zlib1g
 Priority: optional
 Description: A simple GUI for kanshi.
 EOS
 
-DEB_FILE="build/${DEB_PACKAGE_NAME}_${VERSION}_${ARCH}.deb"
+DEB_FILE="build/${DEB_PACKAGE_NAME}_${VERSION}_${DEB_ARCH}.deb"
 dpkg-deb --build "$PKG_DIR" "$DEB_FILE"
 
 echo "Package built: $DEB_FILE"


### PR DESCRIPTION
## Summary
- determine the Debian architecture dynamically and map it to the corresponding Flutter build directory
- use the mapped architecture for the Flutter build target, package contents, and generated .deb filename
- add validation that the expected Flutter bundle exists before packaging

## Testing
- ./scripts/build_deb.sh *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcebe1ac948322a65bab3b17283467