### PR TITLE
Use arm64 runner for ARM Debian build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.arch }} package
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-22.04-arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run the arm64 package build on an ARM-based runner to satisfy Flutter build requirements

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69275b1045088330a03eeb8911ddf6a4)